### PR TITLE
Bump version to 1.0.7-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.6-SNAPSHOT"
+version in ThisBuild := "1.0.7-SNAPSHOT"


### PR DESCRIPTION
1.0.6 is already released, so the project should be on the next version's SNAPSHOT.

Running `sbt release` will move the version from 1.0.X-SNAPSHOT to 1.0.X and tag it a v1.0.X, then it will bump to 1.0.${X+1}-SNAPSHOT for future development.