### PR TITLE
Pass docker settings via java system properties

### DIFF
--- a/examples/basic-with-tests/project/plugins.sbt
+++ b/examples/basic-with-tests/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.2.0")
 
-addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.6")
+addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.7-SNAPSHOT")

--- a/examples/basic-with-tests/src/test/scala/BasicAppSpec.scala
+++ b/examples/basic-with-tests/src/test/scala/BasicAppSpec.scala
@@ -41,6 +41,11 @@ class BasicAppSpec extends fixture.FunSuite with fixture.ConfigMapFixture with E
     configMap =>
   }
 
+  test("Validate presence of docker config information in system properties", DockerComposeTag) {
+    configMap =>
+      Option(System.getProperty(basicServiceHostKey)) shouldBe defined
+  }
+
   def getHostInfo(configMap: ConfigMap): String = getContainerSetting(configMap, basicServiceHostKey)
   def getContainerId(configMap: ConfigMap): String = getContainerSetting(configMap, basicServiceContainerIdKey)
 

--- a/src/main/scala/com/tapad/docker/ComposeTestRunner.scala
+++ b/src/main/scala/com/tapad/docker/ComposeTestRunner.scala
@@ -70,7 +70,7 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
 
     val testDependencies = getTestDependenciesClassPath
     if (testDependencies.contains("org.scalatest")) {
-      s"java $debugSettings -cp $testDependencies org.scalatest.tools.Runner -o -R ${getSetting(testCasesJar)} $testTags $testParams".!
+      s"java $debugSettings $testParams -cp $testDependencies org.scalatest.tools.Runner -o -R ${getSetting(testCasesJar)} $testTags $testParams".!
     } else {
       printBold("Cannot find a ScalaTest Jar dependency. Please make sure it is added to your sbt projects " +
         "libraryDependencies.")


### PR DESCRIPTION
Docker settings (IP and port for containers) are already passed to the
ScalaTest runner with the -D flag so they can be passed to tests using
the configMap, with keys like "$containerId:$containerInternalPort";
this is by mixing in org.scalatest.fixture.ConfigMapFixture to the test
suite.

This patch passes the same key/value pairs to the underlying JVM as system
properties, which is useful when the application uses system properties
to set configuration during boot, which is a common pattern in Play
Framework using TypeSafe's ConfigFactory.