### PR TITLE
Added the ability to handle unsupported fields in Compose file. 

### DIFF
--- a/src/main/scala/com/tapad/docker/ComposeFile.scala
+++ b/src/main/scala/com/tapad/docker/ComposeFile.scala
@@ -33,8 +33,8 @@ trait ComposeFile extends SettingsHelper with ComposeCustomTagHelpers with Print
 
   val environmentDebugKey = "JAVA_TOOL_OPTIONS"
 
-  //Unsupported fields
-  val unSupportedFields = List("build", "container_name", "extends")
+  //List of docker-compose fields that are currently unsupported by the plugin
+  val unsupportedFields = List("build", "container_name", "extends")
 
   type yamlData = Map[String, java.util.LinkedHashMap[String, Any]]
 
@@ -55,9 +55,8 @@ trait ComposeFile extends SettingsHelper with ComposeCustomTagHelpers with Print
 
     getComposeFileServices(composeYaml).map { service =>
       val (serviceName, serviceData) = service
-      for (field <- unSupportedFields if serviceData.containsKey(field)) {
-        val errMsg = s"Compose field '$field:' is not supported. Please check README for all the unsupported fields."
-        throw ComposeFileFormatException(errMsg)
+      for (field <- unsupportedFields if serviceData.containsKey(field)) {
+        throw ComposeFileFormatException(getUnsupportedFieldErrorMsg(field))
       }
       val imageName = serviceData.get(imageKey).toString
 
@@ -95,10 +94,16 @@ trait ComposeFile extends SettingsHelper with ComposeCustomTagHelpers with Print
     }
   }
 
+  def getUnsupportedFieldErrorMsg(fieldName: String): String = {
+    s"Docker Compose field '$fieldName:' is currently not supported by sbt-docker-compose. Please see the README for " +
+      s"more information on the set of unsupported fields."
+  }
+
   /**
    *  Attempt to get the fully qualified path to the environment file. It will first attempt to find the file using the
    *  path provided. If that fails it will attempt to find the file relative to the docker-compose yml location. Otherwise,
    *  it will throw an exception with information about the file that could not be located.
+   *
    * @param fileName The file name to find
    * @param composePath The path to the directory of the docker-compose yml file being used
    * @return The fully qualified path to the file

--- a/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
@@ -10,6 +10,12 @@ import scala.concurrent.duration._
 import scala.util.Try
 
 /**
+ * The exception type to be thrown when there is a format issue in the Compose file
+ * @param message The error message to be displayed on the console
+ */
+case class ComposeFileFormatException(message: String) extends Exception(message)
+
+/**
  * Defines an internal to external port mapping for a Docker Compose service port
  *
  * @param hostPort The port that is externally exposed for access from the Docker host machine
@@ -82,8 +88,7 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
     s"Supply '$skipPullArg' as a parameter to use local images instead of pulling the latest from the Docker Registry. " +
       s"Supply '$skipBuildArg' as a parameter to use the current Docker image for the main project instead of building a new one.", "") {
       (state: State, args: Seq[String]) =>
-
-        launchInstanceWithLatestChanges(state, args)
+        runWithCustomErrorsHandling(state, args, launchInstanceWithLatestChanges)
     }
 
   lazy val dockerComposeStopCommand = Command.args("dockerComposeStop", ("dockerComposeStop", "Stops all local Docker " +
@@ -109,8 +114,20 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
       s"Supply '$testTagOverride:<tagName1,tagName2>' as a parameter to override the tags specified in the testTagsToExecute setting." +
       "To execute a test pass against a previously started dockerComposeUp instance just pass the instance id to the command as a parameter", "") { (state: State, args: Seq[String]) =>
 
-      composeTestRunner(state, args)
+      runWithCustomErrorsHandling(state, args, composeTestRunner(_, _))
+
     }
+
+  def runWithCustomErrorsHandling(state: State, args: Seq[String], fn: (State, Seq[String]) => State): State = {
+    try {
+      fn(state, args)
+    } catch {
+      case ex: ComposeFileFormatException => {
+        printError(ex.message)
+        state
+      }
+    }
+  }
 
   def launchInstanceWithLatestChanges(state: State, args: Seq[String]): State = {
     val newState = getPersistedState(state)

--- a/src/test/resources/unsupported_field_build.yml
+++ b/src/test/resources/unsupported_field_build.yml
@@ -1,5 +1,4 @@
 testservice:
-  image: testservice:latest
   build: /path/to/build/dir
   environment:
     JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005

--- a/src/test/resources/unsupported_field_build.yml
+++ b/src/test/resources/unsupported_field_build.yml
@@ -1,0 +1,7 @@
+testservice:
+  image: testservice:latest
+  build: /path/to/build/dir
+  environment:
+    JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+  ports:
+    - "0:5005"

--- a/src/test/resources/unsupported_field_container_name.yml
+++ b/src/test/resources/unsupported_field_container_name.yml
@@ -1,0 +1,7 @@
+testservice:
+  image: testservice:latest
+  container_name: my-test-container
+  environment:
+    JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+  ports:
+    - "0:5005"

--- a/src/test/resources/unsupported_field_extends.yml
+++ b/src/test/resources/unsupported_field_extends.yml
@@ -1,6 +1,6 @@
 testservice:
-   extends:
-     file: debug_port.yml
-     service: testservice
-   ports:
-     - "8000:8000"
+  extends:
+   file: debug_port.yml
+   service: testservice
+  ports:
+   - "8000:8000"

--- a/src/test/resources/unsupported_field_extends.yml
+++ b/src/test/resources/unsupported_field_extends.yml
@@ -1,0 +1,6 @@
+testservice:
+   extends:
+     file: debug_port.yml
+     service: testservice
+   ports:
+     - "8000:8000"

--- a/src/test/scala/ComposeFileProcessingSpec.scala
+++ b/src/test/scala/ComposeFileProcessingSpec.scala
@@ -12,36 +12,36 @@ import sbt.Keys._
 class ComposeFileProcessingSpec extends FunSuite with BeforeAndAfter with OneInstancePerTest with MockitoSugar {
 
   test("Validate Compose field 'build:' results in correct exception thrown and error message printing") {
-    val composeMock = getComposeFileMock(serviceName = "nomatch")
+    val composeMock = getComposeFileMock()
     val composeFilePath = getClass.getResource("unsupported_field_build.yml").getPath
     val composeYaml = composeMock.readComposeFile(composeFilePath)
 
     val thrown = intercept[ComposeFileFormatException] {
       composeMock.processCustomTags(null, null, composeYaml)
     }
-    assert(thrown.getMessage === "Compose field 'build:' is not supported. Please check README for all the unsupported fields.")
+    assert(thrown.getMessage == getUnsupportedFieldErrorMsg("build"))
   }
 
   test("Validate Compose field 'container_name:' results in correct exception thrown and error message printing") {
-    val composeMock = getComposeFileMock(serviceName = "nomatch")
+    val composeMock = getComposeFileMock()
     val composeFilePath = getClass.getResource("unsupported_field_container_name.yml").getPath
     val composeYaml = composeMock.readComposeFile(composeFilePath)
 
     val thrown = intercept[ComposeFileFormatException] {
       composeMock.processCustomTags(null, null, composeYaml)
     }
-    assert(thrown.getMessage === "Compose field 'container_name:' is not supported. Please check README for all the unsupported fields.")
+    assert(thrown.getMessage == getUnsupportedFieldErrorMsg("container_name"))
   }
 
   test("Validate Compose field 'extends:' results in correct exception thrown and error message printing") {
-    val composeMock = getComposeFileMock(serviceName = "nomatch")
+    val composeMock = getComposeFileMock()
     val composeFilePath = getClass.getResource("unsupported_field_extends.yml").getPath
     val composeYaml = composeMock.readComposeFile(composeFilePath)
 
     val thrown = intercept[ComposeFileFormatException] {
       composeMock.processCustomTags(null, null, composeYaml)
     }
-    assert(thrown.getMessage === "Compose field 'extends:' is not supported. Please check README for all the unsupported fields.")
+    assert(thrown.getMessage == getUnsupportedFieldErrorMsg("extends"))
   }
 
   test("Validate Compose <localBuild> tag results in 'build' image source and custom tag is removed") {

--- a/src/test/scala/ComposeFileProcessingSpec.scala
+++ b/src/test/scala/ComposeFileProcessingSpec.scala
@@ -3,13 +3,46 @@ import java.util
 
 import com.tapad.docker.DockerComposeKeys._
 import com.tapad.docker.DockerComposePlugin._
-import com.tapad.docker.{ ComposeFile, DockerComposePluginLocal }
+import com.tapad.docker.{ ComposeFile, ComposeFileFormatException, DockerComposePluginLocal }
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ BeforeAndAfter, FunSuite, OneInstancePerTest }
 import sbt.Keys._
 
 class ComposeFileProcessingSpec extends FunSuite with BeforeAndAfter with OneInstancePerTest with MockitoSugar {
+
+  test("Validate Compose field 'build:' results in correct exception thrown and error message printing") {
+    val composeMock = getComposeFileMock(serviceName = "nomatch")
+    val composeFilePath = getClass.getResource("unsupported_field_build.yml").getPath
+    val composeYaml = composeMock.readComposeFile(composeFilePath)
+
+    val thrown = intercept[ComposeFileFormatException] {
+      composeMock.processCustomTags(null, null, composeYaml)
+    }
+    assert(thrown.getMessage === "Compose field 'build:' is not supported. Please check README for all the unsupported fields.")
+  }
+
+  test("Validate Compose field 'container_name:' results in correct exception thrown and error message printing") {
+    val composeMock = getComposeFileMock(serviceName = "nomatch")
+    val composeFilePath = getClass.getResource("unsupported_field_container_name.yml").getPath
+    val composeYaml = composeMock.readComposeFile(composeFilePath)
+
+    val thrown = intercept[ComposeFileFormatException] {
+      composeMock.processCustomTags(null, null, composeYaml)
+    }
+    assert(thrown.getMessage === "Compose field 'container_name:' is not supported. Please check README for all the unsupported fields.")
+  }
+
+  test("Validate Compose field 'extends:' results in correct exception thrown and error message printing") {
+    val composeMock = getComposeFileMock(serviceName = "nomatch")
+    val composeFilePath = getClass.getResource("unsupported_field_extends.yml").getPath
+    val composeYaml = composeMock.readComposeFile(composeFilePath)
+
+    val thrown = intercept[ComposeFileFormatException] {
+      composeMock.processCustomTags(null, null, composeYaml)
+    }
+    assert(thrown.getMessage === "Compose field 'extends:' is not supported. Please check README for all the unsupported fields.")
+  }
 
   test("Validate Compose <localBuild> tag results in 'build' image source and custom tag is removed") {
     val composeMock = getComposeFileMock(serviceName = "nomatch")


### PR DESCRIPTION
A custom exception 'ComposeFileFormatException' is thrown and catched by the plugin. Instead of showing the stack trace, the plugin shows an red error message on the console.