### PR TITLE
Add sorting to table output

### DIFF
--- a/src/main/scala/com/tapad/docker/OutputTableRow.scala
+++ b/src/main/scala/com/tapad/docker/OutputTableRow.scala
@@ -1,0 +1,41 @@
+package com.tapad.docker
+
+case class OutputTableRow(
+    serviceName: String,
+    hostWithPort: String,
+    versionTag: String,
+    imageSource: String,
+    containerPort: String,
+    containerId: String,
+    isDebug: Boolean
+) extends Ordered[OutputTableRow] {
+
+  def toStringList: List[String] =
+    List(
+      serviceName,
+      hostWithPort,
+      versionTag,
+      imageSource,
+      containerPort,
+      containerId,
+      if (isDebug) "DEBUG" else ""
+    )
+
+  def compare(that: OutputTableRow): Int = {
+    // Sort Order
+    // - Service Name - Alphabetically
+    // - isDebug - Debug Ports always go at the end
+    // - Container Port - Sorted by port number from lowest to highest
+    if (this.serviceName == that.serviceName) {
+      if (this.isDebug == that.isDebug) {
+        val leftContainerPort = this.containerPort.split("/").head.toInt
+        val rightContainerPort = that.containerPort.split("/").head.toInt
+        leftContainerPort compare rightContainerPort
+      } else {
+        this.isDebug compare that.isDebug
+      }
+    } else {
+      this.serviceName compare that.serviceName
+    }
+  }
+}

--- a/src/test/resources/sort.yml
+++ b/src/test/resources/sort.yml
@@ -1,0 +1,17 @@
+testserviceB:
+  image: testservice:latest
+  environment:
+    JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+  ports:
+    - "0:5005"
+    - "0:80"
+    - "0:10000"
+    - "0:8000/udp"
+testserviceA:
+  image: testserviceA:latest
+  environment:
+    JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+  ports:
+    - "0:5005"
+    - "0:2003"
+    - "0:12345"


### PR DESCRIPTION
There were inconsistencies between different sessions of dockerComposeUp where the container ports were random each time. The change is to always print a sorted table in the order of service name, isDebug, and container port. Also did minor code cleanup and added an unit test.

@kurtkopchik 