### PR TITLE
Fixes #23 Update command state on test failure

### DIFF
--- a/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
@@ -410,9 +410,9 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
     val newState = getPersistedState(state)
 
     val requiresShutdown = getMatchingRunningInstance(newState, args).isEmpty
-    val (finalState, instance) = getTestPassInstance(newState, args)
+    val (preTestState, instance) = getTestPassInstance(newState, args)
 
-    runTestPass(finalState, args, instance)
+    val finalState = runTestPass(preTestState, args, instance)
 
     if (requiresShutdown)
       stopDockerCompose(finalState, Seq(instance.get.instanceName))


### PR DESCRIPTION
Changes the test running function to return a state object. This allows the state to be set to a failure if the test runner gives a non-zero exit code, which means SBT can fail with a non-zero code despite the containers starting and stopping properly. This allows CI applications to properly detect failures.