### PR TITLE
Add new task "testExecutionExtraEnvironment"

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ plugin will attempt to locate it in one of three places with the precedence orde
     dockerImageCreationTask := // The sbt task used to create a Docker image. For sbt-docker this should be set to 'docker.value' for the sbt-native-packager this should be set to '(publishLocal in Docker).value'.
     testTagsToExecute =: // Set of ScalaTest Tags to execute when dockerComposeTest is run. Separate multiple tags by a comma. It defaults to executing all tests.
     testExecutionArgs =: // Additional ScalaTest Runner argument options to pass into the test runner. For example, this can be used for the generation of test reports.
+    testExecutionExtraConfigTask =: // An sbt task that returns a Map[String,String] of variables which should be passed into the ScalaTest Runner ConfigMap (in addition to standard service/port mappings).
     testDependenciesClasspath =: // The path to all managed and unmanaged Test and Compile dependencies. This path needs to include the ScalaTest Jar for the tests to execute. This defaults to all managedClasspath and unmanagedClasspath in the Test and fullClasspath in the Compile Scope.
     testCasesJar =: // The path to the Jar file containing the tests to execute. This defaults to the Jar file with the tests from the current sbt project.
     testCasesPackageTask := // The sbt Task to package the test cases used when running 'dockerComposeTest'. This defaults to the 'packageBin' task in the 'Test' Scope.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ plugin will attempt to locate it in one of three places with the precedence orde
     dockerImageCreationTask := // The sbt task used to create a Docker image. For sbt-docker this should be set to 'docker.value' for the sbt-native-packager this should be set to '(publishLocal in Docker).value'.
     testTagsToExecute =: // Set of ScalaTest Tags to execute when dockerComposeTest is run. Separate multiple tags by a comma. It defaults to executing all tests.
     testExecutionArgs =: // Additional ScalaTest Runner argument options to pass into the test runner. For example, this can be used for the generation of test reports.
-    testExecutionExtraConfigTask =: // An sbt task that returns a Map[String,String] of variables which should be passed into the ScalaTest Runner ConfigMap (in addition to standard service/port mappings).
+    testExecutionExtraConfigTask =: // An sbt task that returns a Map[String,String] of variables to pass into the ScalaTest Runner ConfigMap (in addition to standard service/port mappings).
     testDependenciesClasspath =: // The path to all managed and unmanaged Test and Compile dependencies. This path needs to include the ScalaTest Jar for the tests to execute. This defaults to all managedClasspath and unmanagedClasspath in the Test and fullClasspath in the Compile Scope.
     testCasesJar =: // The path to the Jar file containing the tests to execute. This defaults to the Jar file with the tests from the current sbt project.
     testCasesPackageTask := // The sbt Task to package the test cases used when running 'dockerComposeTest'. This defaults to the 'packageBin' task in the 'Test' Scope.

--- a/src/main/scala/com/tapad/docker/ComposeTestRunner.scala
+++ b/src/main/scala/com/tapad/docker/ComposeTestRunner.scala
@@ -34,8 +34,9 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
   /**
    * Gets extra key value pairs to pass to ScalaTest in the configMap.
    * @param state The sbt state
+   * @return A Map[String,String] of variables to pass into the ScalaTest Runner ConfigMap
    */
-  def runVariablesForTestEnvTask(state: State): Map[String, String] = {
+  def runTestExecutionExtraConfigTask(state: State): Map[String, String] = {
     val extracted = Project.extract(state)
     val (_, value) = extracted.runTask(testExecutionExtraConfigTask, state)
     value
@@ -64,7 +65,7 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
       case None => ""
     }
 
-    val extraTestParams = runVariablesForTestEnvTask(state).map { case (k, v) => s"-D$k=$v" }
+    val extraTestParams = runTestExecutionExtraConfigTask(state).map { case (k, v) => s"-D$k=$v" }
 
     print("Compiling and Packaging test cases...")
     binPackageTests

--- a/src/main/scala/com/tapad/docker/DockerCommands.scala
+++ b/src/main/scala/com/tapad/docker/DockerCommands.scala
@@ -90,4 +90,9 @@ trait DockerCommands {
     val extracted = Project.extract(state)
     extracted.runTask(variablesForSubstitutionTask, state)._2.toVector
   }
+
+  def runVariablesForTestEnvTask(state: State): Map[String, String] = {
+    val extracted = Project.extract(state)
+    extracted.runTask(testExecutionExtraEnvironment, state)._2
+  }
 }

--- a/src/main/scala/com/tapad/docker/DockerCommands.scala
+++ b/src/main/scala/com/tapad/docker/DockerCommands.scala
@@ -88,11 +88,13 @@ trait DockerCommands {
    */
   def runVariablesForSubstitutionTask(state: State): Vector[(String, String)] = {
     val extracted = Project.extract(state)
-    extracted.runTask(variablesForSubstitutionTask, state)._2.toVector
+    val (_, value) = extracted.runTask(variablesForSubstitutionTask, state)
+    value.toVector
   }
 
   def runVariablesForTestEnvTask(state: State): Map[String, String] = {
     val extracted = Project.extract(state)
-    extracted.runTask(testExecutionExtraEnvironment, state)._2
+    val (_, value) = extracted.runTask(testExecutionExtraEnvironment, state)
+    value
   }
 }

--- a/src/main/scala/com/tapad/docker/DockerCommands.scala
+++ b/src/main/scala/com/tapad/docker/DockerCommands.scala
@@ -91,10 +91,4 @@ trait DockerCommands {
     val (_, value) = extracted.runTask(variablesForSubstitutionTask, state)
     value.toVector
   }
-
-  def runVariablesForTestEnvTask(state: State): Map[String, String] = {
-    val extracted = Project.extract(state)
-    val (_, value) = extracted.runTask(testExecutionExtraEnvironment, state)
-    value
-  }
 }

--- a/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
@@ -16,6 +16,7 @@ trait DockerComposeKeysLocal {
   val dockerMachineName = settingKey[String]("If running on OSX the name of the Docker Machine Virtual machine being used. If not overridden it is set to 'default'")
   val dockerImageCreationTask = taskKey[Any]("The sbt task used to create a Docker image. For sbt-docker this should be set to 'docker.value' for the sbt-native-packager this should be set to '(publishLocal in Docker).value'.")
   val testTagsToExecute = settingKey[String]("Set of ScalaTest Tags to execute when dockerComposeTest is run. Separate multiple tags by a comma. It defaults to executing all tests.")
+  val testExecutionExtraEnvironment = taskKey[Map[String, String]]("Additional ScalaTest Runner environment variables that will be passed into the ConfigMap.")
   val testExecutionArgs = settingKey[String]("Additional ScalaTest Runner argument options to pass into the test runner. For example, this can be used for the generation of test reports.")
   val testCasesJar = settingKey[String]("The path to the Jar file containing the tests to execute. This defaults to the Jar file with the tests from the current sbt project.")
   val testCasesPackageTask = taskKey[File]("The sbt TaskKey to package the test cases used when running 'dockerComposeTest'. This defaults to the 'packageBin' task in the 'Test' Scope.")

--- a/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
@@ -16,7 +16,7 @@ trait DockerComposeKeysLocal {
   val dockerMachineName = settingKey[String]("If running on OSX the name of the Docker Machine Virtual machine being used. If not overridden it is set to 'default'")
   val dockerImageCreationTask = taskKey[Any]("The sbt task used to create a Docker image. For sbt-docker this should be set to 'docker.value' for the sbt-native-packager this should be set to '(publishLocal in Docker).value'.")
   val testTagsToExecute = settingKey[String]("Set of ScalaTest Tags to execute when dockerComposeTest is run. Separate multiple tags by a comma. It defaults to executing all tests.")
-  val testExecutionExtraEnvironment = taskKey[Map[String, String]]("Additional ScalaTest Runner environment variables that will be passed into the ConfigMap.")
+  val testExecutionExtraConfigTask = taskKey[Map[String, String]]("Additional ScalaTest Runner configuration that will be passed into the ConfigMap.")
   val testExecutionArgs = settingKey[String]("Additional ScalaTest Runner argument options to pass into the test runner. For example, this can be used for the generation of test reports.")
   val testCasesJar = settingKey[String]("The path to the Jar file containing the tests to execute. This defaults to the Jar file with the tests from the current sbt project.")
   val testCasesPackageTask = taskKey[File]("The sbt TaskKey to package the test cases used when running 'dockerComposeTest'. This defaults to the 'packageBin' task in the 'Test' Scope.")

--- a/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
@@ -16,7 +16,7 @@ trait DockerComposeKeysLocal {
   val dockerMachineName = settingKey[String]("If running on OSX the name of the Docker Machine Virtual machine being used. If not overridden it is set to 'default'")
   val dockerImageCreationTask = taskKey[Any]("The sbt task used to create a Docker image. For sbt-docker this should be set to 'docker.value' for the sbt-native-packager this should be set to '(publishLocal in Docker).value'.")
   val testTagsToExecute = settingKey[String]("Set of ScalaTest Tags to execute when dockerComposeTest is run. Separate multiple tags by a comma. It defaults to executing all tests.")
-  val testExecutionExtraConfigTask = taskKey[Map[String, String]]("Additional ScalaTest Runner configuration that will be passed into the ConfigMap.")
+  val testExecutionExtraConfigTask = taskKey[Map[String, String]]("Additional ScalaTest Runner configuration to pass into the ConfigMap.")
   val testExecutionArgs = settingKey[String]("Additional ScalaTest Runner argument options to pass into the test runner. For example, this can be used for the generation of test reports.")
   val testCasesJar = settingKey[String]("The path to the Jar file containing the tests to execute. This defaults to the Jar file with the tests from the current sbt project.")
   val testCasesPackageTask = taskKey[File]("The sbt TaskKey to package the test cases used when running 'dockerComposeTest'. This defaults to the 'packageBin' task in the 'Test' Scope.")

--- a/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
@@ -72,7 +72,7 @@ object DockerComposePlugin extends DockerComposePluginLocal {
     val testDependenciesClasspath = DockerComposeKeys.testDependenciesClasspath
     val testCasesPackageTask = DockerComposeKeys.testCasesPackageTask
     val testTagsToExecute = DockerComposeKeys.testTagsToExecute
-    val testExecutionExtraEnvironment = DockerComposeKeys.testExecutionExtraEnvironment
+    val testExecutionExtraConfigTask = DockerComposeKeys.testExecutionExtraConfigTask
     val testExecutionArgs = DockerComposeKeys.testExecutionArgs
     val testCasesJar = DockerComposeKeys.testCasesJar
     val scalaTestJar = DockerComposeKeys.testDependenciesClasspath
@@ -416,7 +416,7 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
     val requiresShutdown = getMatchingRunningInstance(newState, args).isEmpty
     val (preTestState, instance) = getTestPassInstance(newState, args)
 
-    val finalState = runTestPass(preTestState, args, instance, runVariablesForTestEnvTask(state))
+    val finalState = runTestPass(preTestState, args, instance)
 
     if (requiresShutdown)
       stopDockerCompose(finalState, Seq(instance.get.instanceName))

--- a/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
@@ -72,6 +72,7 @@ object DockerComposePlugin extends DockerComposePluginLocal {
     val testDependenciesClasspath = DockerComposeKeys.testDependenciesClasspath
     val testCasesPackageTask = DockerComposeKeys.testCasesPackageTask
     val testTagsToExecute = DockerComposeKeys.testTagsToExecute
+    val testExecutionExtraEnvironment = DockerComposeKeys.testExecutionExtraEnvironment
     val testExecutionArgs = DockerComposeKeys.testExecutionArgs
     val testCasesJar = DockerComposeKeys.testCasesJar
     val scalaTestJar = DockerComposeKeys.testDependenciesClasspath
@@ -415,7 +416,7 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
     val requiresShutdown = getMatchingRunningInstance(newState, args).isEmpty
     val (preTestState, instance) = getTestPassInstance(newState, args)
 
-    val finalState = runTestPass(preTestState, args, instance)
+    val finalState = runTestPass(preTestState, args, instance, runVariablesForTestEnvTask(state))
 
     if (requiresShutdown)
       stopDockerCompose(finalState, Seq(instance.get.instanceName))

--- a/src/main/scala/com/tapad/docker/DockerComposeSettings.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeSettings.scala
@@ -35,7 +35,7 @@ trait DockerComposeSettingsLocal extends PrintFormatting {
     dockerImageCreationTask := printError("***Warning: The 'dockerImageCreationTask' has not been defined. " +
       "Please configure this setting to have Docker images built.***"),
     testTagsToExecute := "",
-    testExecutionExtraEnvironment := Map.empty[String, String],
+    testExecutionExtraConfigTask := Map.empty[String, String],
     testExecutionArgs := "",
     testDependenciesClasspath := {
       val fullClasspathCompile = (fullClasspath in Compile).value

--- a/src/main/scala/com/tapad/docker/DockerComposeSettings.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeSettings.scala
@@ -35,6 +35,7 @@ trait DockerComposeSettingsLocal extends PrintFormatting {
     dockerImageCreationTask := printError("***Warning: The 'dockerImageCreationTask' has not been defined. " +
       "Please configure this setting to have Docker images built.***"),
     testTagsToExecute := "",
+    testExecutionExtraEnvironment := Map.empty[String, String],
     testExecutionArgs := "",
     testDependenciesClasspath := {
       val fullClasspathCompile = (fullClasspath in Compile).value


### PR DESCRIPTION
This allows extra environment variables to be passed to the ScalaTest
Runner (in addition to the default serviceName:containerPort ->
host:hostPort and related service -> container information).

One reason for doing this is to eliminate hardcoded shared credentials
for configuring a service in docker-compose.yml and any test code that
needs to connect to the service.

For example, you can do this:

    build.sbt
    ----
    variablesForSubstitutionTask := {
       val random1 = Random.alphanumeric.take(20).mkString
       val random2 = Random.alphanumeric.take(20).mkString
       Map("SUPER_SECRET" -> random1, "USER" -> random2)
    }

    testExecutionExtraEnvironment := variablesForSubstitutionTask.value



    docker-compose.yml
    ----
    services:
      some_secret_service:
        image: <some image>
        ports:
          "9000"
        environment:
          USERNAME: "${USER}"
          PASSWORD: "${SUPER_SECRET}"



    SomeSpec.scala
    ----
    class SomeSpec ... {
      test("Validate we can log in") {
        configMap => {
           val hostAndPort = configMap.getRequired[String]("some_secret_service:9000")

           val user = configMap.getRequired[String]("USER")
           val password = configMap.getRequired[String]("SUPER_SECRET")

           val someService = new SomeService(hostAndPort)
           assert(someService.isAuthorisedToLogIn(user, password))