### PR TITLE
getDockerContainerId now also returns values for stopped containers.

### DIFF
--- a/src/main/scala/com/tapad/docker/DockerCommands.scala
+++ b/src/main/scala/com/tapad/docker/DockerCommands.scala
@@ -31,7 +31,7 @@ trait DockerCommands {
 
   def getDockerContainerId(instanceName: String, serviceName: String): String = {
     //Docker replaces '/' with '_' in the identifier string so search for replaced version
-    s"""docker ps --filter=name=${instanceName.replace('/', '_')}_${serviceName}_ --format=\"{{.ID}}\"""".!!.trim().replaceAll("\"", "")
+    s"""docker ps --all --filter=name=${instanceName.replace('/', '_')}_${serviceName}_ --format=\"{{.ID}}\"""".!!.trim().replaceAll("\"", "")
   }
 
   def getDockerContainerInfo(containerId: String): String = {


### PR DESCRIPTION
Fix for issue #54 