### PR TITLE
Cross-build for sbt 0.13 and sbt 1.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")

--- a/src/main/scala/com/tapad/docker/ComposeTestRunner.scala
+++ b/src/main/scala/com/tapad/docker/ComposeTestRunner.scala
@@ -5,6 +5,7 @@ import sbt._
 import sbt.Project
 
 import scala.collection.Seq
+import scala.sys.process.Process
 
 trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
   val testDebugPortArg = "-debug"
@@ -94,7 +95,7 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
         Seq("-R", s"${getSetting(testCasesJar).replace(" ", "\\ ")}") ++
         testTags.split(" ").toSeq ++
         testParamsList).filter(_.nonEmpty)
-      if (testRunnerCommand.! == 0) state
+      if (Process(testRunnerCommand).! == 0) state
       else state.fail
     } else {
       printBold("Cannot find a ScalaTest Jar dependency. Please make sure it is added to your sbt projects " +
@@ -144,7 +145,7 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
         Seq("-cp", testDependencies, "org.specs2.runner.files") ++
         testArgs ++
         testParamsList).filter(_.nonEmpty)
-      if (testRunnerCommand.! == 0) state
+      if (Process(testRunnerCommand).! == 0) state
       else state.fail
     } else {
       printBold("Cannot find a Specs2 Jar dependency. Please make sure it is added to your sbt projects " +

--- a/src/main/scala/com/tapad/docker/DockerCommands.scala
+++ b/src/main/scala/com/tapad/docker/DockerCommands.scala
@@ -1,84 +1,85 @@
 package com.tapad.docker
 
 import sbt._
+import scala.sys.process.Process
 import com.tapad.docker.DockerComposeKeys._
 
 trait DockerCommands {
   def dockerComposeUp(instanceName: String, composePath: String): Int = {
-    s"docker-compose -p $instanceName -f $composePath up -d".!
+    Process(s"docker-compose -p $instanceName -f $composePath up -d").!
   }
 
   def dockerComposeStopInstance(instanceName: String, composePath: String): Unit = {
-    s"docker-compose -p $instanceName -f $composePath stop".!
+    Process(s"docker-compose -p $instanceName -f $composePath stop").!
   }
 
   def dockerComposeRemoveContainers(instanceName: String, composePath: String): Unit = {
-    s"docker-compose -p $instanceName -f $composePath rm -v -f".!
+    Process(s"docker-compose -p $instanceName -f $composePath rm -v -f").!
   }
 
   def dockerNetworkExists(instanceName: String, networkName: String): Boolean = {
     //Docker replaces '/' with '_' in the identifier string so search for replaced version
     //Use '-q' instead of '--format' as format was only introduced in Docker v1.13.0-rc1
-    s"docker network ls -q --filter=name=${instanceName.replace('/', '_')}_$networkName".!!.trim().nonEmpty
+    Process(s"docker network ls -q --filter=name=${instanceName.replace('/', '_')}_$networkName").!!.trim().nonEmpty
   }
 
   def dockerVolumeExists(instanceName: String, volumeName: String): Boolean = {
     //Docker replaces '/' with '_' in the identifier string so search for replaced version
-    s"docker volume ls -q --filter=name=${instanceName.replace('/', '_')}_$volumeName".!!.trim().nonEmpty
+    Process(s"docker volume ls -q --filter=name=${instanceName.replace('/', '_')}_$volumeName").!!.trim().nonEmpty
   }
 
   def getDockerComposeVersion: Version = {
-    val version = "docker-compose version --short".!!
+    val version = Process("docker-compose version --short").!!
     Version(version)
   }
 
   def dockerPull(imageName: String): Unit = {
-    s"docker pull $imageName".!
+    Process(s"docker pull $imageName").!
   }
 
   def dockerMachineIp(machineName: String): String = {
-    s"docker-machine ip $machineName".!!.trim
+    Process(s"docker-machine ip $machineName").!!.trim
   }
 
   def getDockerContainerId(instanceName: String, serviceName: String): String = {
     //Docker replaces '/' with '_' in the identifier string so search for replaced version
-    s"""docker ps --all --filter=name=${instanceName.replace('/', '_')}_${serviceName}_ --format=\"{{.ID}}\"""".!!.trim().replaceAll("\"", "")
+    Process(s"""docker ps --all --filter=name=${instanceName.replace('/', '_')}_${serviceName}_ --format=\"{{.ID}}\"""").!!.trim().replaceAll("\"", "")
   }
 
   def getDockerContainerInfo(containerId: String): String = {
-    s"docker inspect --type=container $containerId".!!
+    Process(s"docker inspect --type=container $containerId").!!
   }
 
   def dockerRemoveImage(imageName: String): Unit = {
-    s"docker rmi $imageName".!!
+    Process(s"docker rmi $imageName").!!
   }
 
   def dockerRemoveNetwork(instanceName: String, networkName: String): Unit = {
-    s"docker network rm ${instanceName}_$networkName".!
+    Process(s"docker network rm ${instanceName}_$networkName").!
   }
 
   def dockerRemoveVolume(instanceName: String, volumeName: String): Unit = {
-    s"docker volume rm ${instanceName}_$volumeName".!
+    Process(s"docker volume rm ${instanceName}_$volumeName").!
   }
 
   def dockerTagImage(currentImageName: String, newImageName: String): Unit = {
-    s"docker tag $currentImageName $newImageName".!!
+    Process(s"docker tag $currentImageName $newImageName").!!
   }
 
   def dockerPushImage(imageName: String): Unit = {
-    s"docker push $imageName".!
+    Process(s"docker push $imageName").!
   }
 
   def dockerRun(command: String): Unit = {
-    s"docker run $command".!
+    Process(s"docker run $command").!
   }
 
   def getDockerPortMappings(containerId: String): String = {
-    s"docker port $containerId".!!
+    Process(s"docker port $containerId").!!
   }
 
   def isDockerForMacEnvironment: Boolean = {
-    val info = "docker info".!!
+    val info = Process("docker info").!!
     info.contains("Operating System: Alpine Linux") && info.matches("(?s).*Kernel Version:.*-moby.*")
   }
 


### PR DESCRIPTION
Noteworthy changes:
- `sbt.Process` is gone in 1.0, so you have to use the `scala.sys.process` API. Not a big change here since the `scala.sys.process` has been available since 2.9 (iirc) and it *is* the `sbt.Process` API
- The `release` process needs to publish artifacts for multiple versions of sbt, so it needs to be updated to a version that supports `releaseStepCommandAndRemaining` so that we can use `^test` and `^publishSigned` in a release step

Since you're building the plugin for multiple versions of sbt, you should prefix your tasks with the cross-sbt-version operator (`^`) during the iterative development of this plugin, e.g.:
`;^clean ;^compile ;^test`

Otherwise, if you want to target a specific version of sbt during your session, use `^^` and then just issue your tasks without the cross-sbt operator:
```
> ^^1.0.0
[info] Setting `sbtVersion in pluginCrossBuild` to 1.0.0
[info] Set current project to sbt-docker-compose (in build file:/Users/jeffo/Projects/jvm/tapad/sbt-docker-compose/)
> compile
[success] Total time: 1 s, completed Aug 15, 2017 4:00:05 PM
```

`^^` and `^` are similar to how we use `++` and `+` for changing and cross-building against multiple Scala versions.