### PR TITLE
Partial fix for issue #44 — added cucumber support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ plugin will attempt to locate it in one of three places with the precedence orde
     testCasesJar := // The path to the Jar file containing the tests to execute. This defaults to the Jar file with the tests from the current sbt project.
     testCasesPackageTask := // The sbt Task to package the test cases used when running 'dockerComposeTest'. This defaults to the 'packageBin' task in the 'Test' Scope.
     testPassUseSpecs2 := // True if Specs2 is to be used to execute the test pass. This defaults to False and ScalaTest is used.
+    testPassUseCucumber := // True if cucumber is to be used to execute the test pass. This defaults to False and ScalaTest is used.
     variablesForSubstitution := // A Map[String,String] of variables to substitute in your docker-compose file. These are substituted substituted by the plugin and not using environment variables.
     variablesForSubstitutionTask := // An sbt task that returns a Map[String,String] of variables to substitute in your docker-compose file. These are substituted by the plugin and not using environment variables.
    ```
@@ -368,8 +369,16 @@ by setting the following property in build.sbt:
 Additionally, you can override the default Specs2 file runner properties as follows:
 
    ```
-    testExecutionExtraConfigTask := Map("filesrunner.verbose" -> s"true")
+    testExecutionExtraConfigTask := Map("filesrunner.verbose" -> "true")
    ```
+
+8) [**basic-with-tests-cucumber**](examples/basic-with-tests-cucumber): This project shows how to execute cucumber based test cases 
+by setting the following property in build.sbt:
+
+   ```
+    testPassUseCucumber := true
+   ```
+
 
 Currently Unsupported Docker Compose Fields
 -------------------------------------------

--- a/examples/basic-with-tests-cucumber/build.sbt
+++ b/examples/basic-with-tests-cucumber/build.sbt
@@ -1,0 +1,49 @@
+
+
+name := "basic-cucumber"
+
+version := "1.0.0"
+
+scalaVersion := "2.11.11"
+
+enablePlugins(DockerPlugin, DockerComposePlugin, CucumberPlugin)
+
+libraryDependencies ++= {
+  val cucumber = List("core", "jvm", "junit").map(suffix =>
+    "info.cukes" % s"cucumber-$suffix" % "1.2.5" % "test") :+ ("info.cukes" %% "cucumber-scala" % "1.2.5" % "test")
+
+  cucumber ::: List(
+    "org.scalactic" %% "scalactic" % "3.0.4" % "test",
+    "org.scalatest" %% "scalatest" % "3.0.4" % ("test->*"),
+    "org.pegdown" % "pegdown" % "1.6.0" % ("test->*"),
+    "junit" % "junit" % "4.12" % "test"
+  )
+}
+
+CucumberPlugin.glue := "classpath:"
+CucumberPlugin.features += "classpath:"
+
+//Set the image creation Task to be the one used by sbt-docker
+dockerImageCreationTask := docker.value
+
+testPassUseCucumber := true
+
+imageNames in docker := Seq(ImageName(
+  repository = name.value.toLowerCase,
+  tag = Some(version.value))
+)
+
+// create a docker file with a file /inputs/example.input
+dockerfile in docker := {
+
+  val classpath: Classpath = (fullClasspath in Test).value
+  sLog.value.debug(s"Classpath is ${classpath.files.mkString("\n")}\n")
+
+  new Dockerfile {
+    val dockerAppPath = "/app/"
+    from("java")
+    add(classpath.files, dockerAppPath)
+
+    entryPoint("java", "-cp", s"$dockerAppPath:$dockerAppPath*", "example.CalculatorServer")
+  }
+}

--- a/examples/basic-with-tests-cucumber/build.sbt
+++ b/examples/basic-with-tests-cucumber/build.sbt
@@ -1,5 +1,3 @@
-
-
 name := "basic-cucumber"
 
 version := "1.0.0"

--- a/examples/basic-with-tests-cucumber/docker/docker-compose.yml
+++ b/examples/basic-with-tests-cucumber/docker/docker-compose.yml
@@ -2,13 +2,7 @@ version: '3'
 # see https://www.digitalocean.com/community/tutorials/how-to-share-data-between-docker-containers
 # https://docs.docker.com/compose/reference/
 services:
-  basic1:
-    image: "basic:1.0.0"
-
-  basic2:
-    image: "basic:1.0.0"
-    depends_on:
-      - basic1
-    environment:
-      - TESTHOST=http://basic1:8080
-
+  server:
+    image: basic-cucumber:1.0.0
+    ports:
+      - 8080:8080

--- a/examples/basic-with-tests-cucumber/docker/docker-compose.yml
+++ b/examples/basic-with-tests-cucumber/docker/docker-compose.yml
@@ -1,8 +1,6 @@
 version: '3'
-# see https://www.digitalocean.com/community/tutorials/how-to-share-data-between-docker-containers
-# https://docs.docker.com/compose/reference/
 services:
-  server:
+  basic-cucumber:
     image: basic-cucumber:1.0.0
     ports:
       - 8080:8080

--- a/examples/basic-with-tests-cucumber/project/build.properties
+++ b/examples/basic-with-tests-cucumber/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/examples/basic-with-tests-cucumber/project/plugins.sbt
+++ b/examples/basic-with-tests-cucumber/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")
+
+addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.29-SNAPSHOT")
+
+addSbtPlugin("com.waioeka.sbt"  % "cucumber-plugin"      % "0.1.2")

--- a/examples/basic-with-tests-cucumber/project/plugins.sbt
+++ b/examples/basic-with-tests-cucumber/project/plugins.sbt
@@ -1,5 +1,3 @@
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")
-
 addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.29-SNAPSHOT")
-
 addSbtPlugin("com.waioeka.sbt"  % "cucumber-plugin"      % "0.1.2")

--- a/examples/basic-with-tests-cucumber/src/main/scala/example/Calculator.scala
+++ b/examples/basic-with-tests-cucumber/src/main/scala/example/Calculator.scala
@@ -1,0 +1,39 @@
+package example
+
+import java.nio.file.{Files, Path, Paths}
+
+object Calculator {
+
+  def main(args: Array[String]): Unit = {
+    args.toList match {
+      case Nil => println(s"Usage: Expected either two ints or a file path")
+      case List(filePath) =>
+        println(apply(Paths.get(filePath)))
+      case List(a, b) =>
+        println(add(a.toInt, b.toInt))
+      case err => println(s"Usage: Expected either two ints or a file path, but got $err")
+    }
+  }
+
+  def add(x: Int, y: Int): Int = x + y
+
+  def subtract(x: Int, y: Int): Int = x - y
+
+  val PlusR = """(\d+)\s*\+\s*(\d+)""".r
+  val MinusR = """(\d+)\s*-\s*(\d+)""".r
+
+  /**
+    * Evaluates the first line of the input file to be an addition or subtration operation.
+    *
+    * This is just added to demonstrate e.g. composing two containers w/ shared volumes
+    */
+  def apply(input: Path): Int = {
+    import scala.collection.JavaConverters._
+    Files.readAllLines(input).asScala.head match {
+      case PlusR(a, b) => add(a.toInt, b.toInt)
+      case MinusR(a, b) => subtract(a.toInt, b.toInt)
+      case _ => sys.error("Whacha talkin' bout, willis?")
+    }
+  }
+
+}

--- a/examples/basic-with-tests-cucumber/src/main/scala/example/Calculator.scala
+++ b/examples/basic-with-tests-cucumber/src/main/scala/example/Calculator.scala
@@ -2,6 +2,8 @@ package example
 
 import java.nio.file.{Files, Path, Paths}
 
+import scala.collection.JavaConverters._
+
 object Calculator {
 
   def main(args: Array[String]): Unit = {
@@ -28,10 +30,9 @@ object Calculator {
     * This is just added to demonstrate e.g. composing two containers w/ shared volumes
     */
   def apply(input: Path): Int = {
-    import scala.collection.JavaConverters._
-    Files.readAllLines(input).asScala.head match {
-      case PlusR(a, b) => add(a.toInt, b.toInt)
-      case MinusR(a, b) => subtract(a.toInt, b.toInt)
+    Files.readAllLines(input).asScala.headOption match {
+      case Some(PlusR(a, b)) => add(a.toInt, b.toInt)
+      case Some(MinusR(a, b)) => subtract(a.toInt, b.toInt)
       case _ => sys.error("Whacha talkin' bout, willis?")
     }
   }

--- a/examples/basic-with-tests-cucumber/src/main/scala/example/CalculatorClient.scala
+++ b/examples/basic-with-tests-cucumber/src/main/scala/example/CalculatorClient.scala
@@ -1,0 +1,24 @@
+package example
+
+import scala.sys.process._
+
+case class CalculatorClient(hostPort: String) {
+
+  def add(x: Int, y: Int) = curl("add", x, y)
+
+  def subtract(x: Int, y: Int) = curl("subtract", x, y)
+
+  private def curl(path: String, x: Int, y: Int) = {
+    val url = s"${hostPort}/$path/$x/$y"
+    println(s"curling $url")
+    val output = s"curl $url".!!
+    try {
+      output.trim.toInt
+    } catch{
+      case nfe : NumberFormatException =>
+        println(output)
+        throw new Exception(s"$url responded with: >${output}< : $nfe", nfe)
+    }
+  }
+
+}

--- a/examples/basic-with-tests-cucumber/src/main/scala/example/CalculatorServer.scala
+++ b/examples/basic-with-tests-cucumber/src/main/scala/example/CalculatorServer.scala
@@ -1,0 +1,50 @@
+package example
+
+import java.net.InetSocketAddress
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+
+object CalculatorServer extends App {
+  def start(port: Int) = {
+    val server = HttpServer.create(new InetSocketAddress(port), 0)
+    server.createContext("/", Handler)
+    server.start()
+    server
+  }
+
+
+  object Handler extends HttpHandler {
+
+    val AddInput = """/add/([-0-9]+)/([-0-9]+)/?""".r
+    val SubtractInput = """/subtract/([-0-9]+)/([-0-9]+)/?""".r
+
+    override def handle(ex: HttpExchange): Unit = {
+      val path = ex.getRequestURI.toString
+
+      val resultOpt = path match {
+        case AddInput(a, b) => Option(Calculator.add(a.toInt, b.toInt))
+        case SubtractInput(a, b) =>
+          Option(Calculator.subtract(a.toInt, b.toInt))
+        case _ => None
+      }
+
+      val replyString = resultOpt match {
+        case Some(x) =>
+          val response = x.toString
+          ex.sendResponseHeaders(200, response.length)
+          response
+        case None =>
+          val response = s"Unknown path: $path"
+          ex.sendResponseHeaders(404, response.length)
+          response
+      }
+
+      ex.getResponseBody.write(replyString.getBytes)
+    }
+  }
+
+
+  val port = args.headOption.map(_.toInt).getOrElse(8080)
+  println(s"Starting calculator server on port $port w/ user args ${args.mkString(": [", ",", "]")}")
+  start(port)
+}

--- a/examples/basic-with-tests-cucumber/src/main/scala/example/ClientApp.scala
+++ b/examples/basic-with-tests-cucumber/src/main/scala/example/ClientApp.scala
@@ -1,0 +1,9 @@
+package example
+
+object ClientApp extends App {
+  val client = CalculatorClient("http://localhost:8080")
+
+  println(client.add(5, 6))
+  println(client.subtract(5, 6))
+
+}

--- a/examples/basic-with-tests-cucumber/src/test/resources/calculator-service.feature
+++ b/examples/basic-with-tests-cucumber/src/test/resources/calculator-service.feature
@@ -1,0 +1,26 @@
+Feature: Remote Server/Client contract
+
+  Background:
+    And a calculator client against http://localhost:8080
+
+  Scenario Outline: Addition
+    Given a remote request to add <lhs> and <rhs>
+    Then The response should be <sum>
+    Examples:
+      | lhs | rhs | sum |
+      | -1  | 1   | 0   |
+      | 0   | 0   | 0   |
+      | 1   | 0   | 1   |
+      | 0   | 1   | 1   |
+      | 1   | 2   | 3   |
+
+  Scenario Outline: Subtraction
+    Given a remote request to subtract <rhs> from <lhs>
+    Then The response should be <result>
+    Examples:
+      | lhs | rhs | result |
+      | -1  | 1   | -2     |
+      | 0   | 0   | 0      |
+      | 1   | 0   | 1      |
+      | 0   | 1   | -1     |
+      | 1   | 2   | -1     |

--- a/examples/basic-with-tests-cucumber/src/test/resources/calculator.feature
+++ b/examples/basic-with-tests-cucumber/src/test/resources/calculator.feature
@@ -1,0 +1,23 @@
+Feature: Calculator Operations
+
+  Scenario Outline: Addition
+    Given <lhs> + <rhs>
+    Then The result should be <sum>
+    Examples:
+      | lhs | rhs | sum |
+      | -1  | 1   | 0   |
+      | 0   | 0   | 0   |
+      | 1   | 0   | 1   |
+      | 0   | 1   | 1   |
+      | 1   | 2   | 3   |
+
+  Scenario Outline: Subtraction
+    Given <lhs> - <rhs>
+    Then The result should be <result>
+    Examples:
+      | lhs | rhs | result |
+      | -1  | 1   | -2     |
+      | 0   | 0   | 0      |
+      | 1   | 0   | 1      |
+      | 0   | 1   | -1     |
+      | 1   | 2   | -1     |

--- a/examples/basic-with-tests-cucumber/src/test/scala/CalculatorSteps.scala
+++ b/examples/basic-with-tests-cucumber/src/test/scala/CalculatorSteps.scala
@@ -1,0 +1,20 @@
+package example
+
+import cucumber.api.scala.{EN, ScalaDsl}
+import org.scalatest.Matchers
+
+
+class CalculatorSteps extends ScalaDsl with EN with Matchers {
+
+  var lastResult = Int.MinValue
+
+  Given("""^(.+) \+ (.+)$""") { (lhs: Int, rhs: Int) =>
+    lastResult = Calculator.add(lhs, rhs)
+  }
+  Given("""^(.+) - (.+)$""") { (lhs: Int, rhs: Int) =>
+    lastResult = Calculator.subtract(lhs, rhs)
+  }
+  Then("""^The result should be ([-0-9]+)$""") { (expected: Int) =>
+    lastResult shouldBe expected
+  }
+}

--- a/examples/basic-with-tests-cucumber/src/test/scala/CucumberTest.scala
+++ b/examples/basic-with-tests-cucumber/src/test/scala/CucumberTest.scala
@@ -1,0 +1,14 @@
+package example
+
+import cucumber.api.CucumberOptions
+import cucumber.api.junit.Cucumber
+import org.junit.runner.RunWith
+
+@RunWith(classOf[Cucumber])
+@CucumberOptions(
+  features = Array("classpath:"),
+  glue = Array("classpath:"),
+  plugin = Array("pretty", "html:target/cucumber/report.html"),
+  strict = true
+)
+class CucumberTest

--- a/examples/basic-with-tests-cucumber/src/test/scala/ServiceSteps.scala
+++ b/examples/basic-with-tests-cucumber/src/test/scala/ServiceSteps.scala
@@ -1,0 +1,37 @@
+package example
+
+import cucumber.api.scala.{EN, ScalaDsl}
+import org.scalatest.Matchers
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+
+object ServiceSteps {
+  lazy val defaultStartedService = {
+    CalculatorServer.start(8080)
+  }
+}
+
+class ServiceSteps extends ScalaDsl with EN with Matchers with ScalaFutures with Eventually {
+
+  var lastResult = Int.MinValue
+  var client: CalculatorClient = null
+
+  /**
+    * This assumes a running service mapped against the host machine  at the given location
+    */
+  Given("""^a calculator client against (.+)$""") { hostPort: String =>
+    client = CalculatorClient(hostPort)
+
+    // prove connectivity eagerly within this step
+    client.add(0, 0) shouldBe 0
+  }
+
+  Given("""^a remote request to add (.+) and (.+)$""") { (lhs: Int, rhs: Int) =>
+    lastResult = client.add(lhs, rhs)
+  }
+  Given("""^a remote request to subtract (.+) from (.+)$""") { (rhs: Int, lhs: Int) =>
+    lastResult = client.subtract(lhs, rhs)
+  }
+  Then("""^The response should be ([-0-9]+)$""") { (expected: Int) =>
+    lastResult shouldBe expected
+  }
+}

--- a/examples/basic-with-tests-integration/docker/docker-compose.yml
+++ b/examples/basic-with-tests-integration/docker/docker-compose.yml
@@ -1,14 +1,7 @@
-version: '3'
-# see https://www.digitalocean.com/community/tutorials/how-to-share-data-between-docker-containers
-# https://docs.docker.com/compose/reference/
-services:
-  basic1:
-    image: "basic:1.0.0"
-
-  basic2:
-    image: "basic:1.0.0"
-    depends_on:
-      - basic1
-    environment:
-      - TESTHOST=http://basic1:8080
-
+basic:
+  image: basic:1.0.0
+  environment:
+    JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+  ports:
+    - "0:8080"
+    - "0:5005"

--- a/src/main/scala/com/tapad/docker/ComposeTestRunner.scala
+++ b/src/main/scala/com/tapad/docker/ComposeTestRunner.scala
@@ -1,8 +1,7 @@
 package com.tapad.docker
 
 import com.tapad.docker.DockerComposeKeys._
-import sbt._
-import sbt.Project
+import sbt.{ Project, _ }
 
 import scala.collection.Seq
 import scala.sys.process.Process
@@ -13,6 +12,7 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
 
   /**
    * Compiles and binPackages latest test code
+   *
    * @param state The sbt state
    */
   def binPackageTests(implicit state: State): Unit = {
@@ -23,6 +23,7 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
 
   /**
    * Gets a classpath representing all managed and unmanaged dependencies in the Test and Compile Scope for this sbt project.
+   *
    * @param state The sbt state
    * @return The full set of classpath entries used by Test and Compile
    */
@@ -35,6 +36,7 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
 
   /**
    * Gets extra key value pairs to pass to ScalaTest in the configMap.
+   *
    * @param state The sbt state
    * @return A Map[String,String] of variables to pass into the ScalaTest Runner ConfigMap
    */
@@ -52,8 +54,9 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
    * Note: For this to work properly the version of the Scala executable on your path needs to of the same version
    * that the ScalaTest Jar was compiled with. For example,  if you are using ScalaTest 2.10.X Scala must be of
    * version 2.10.X.
-   * @param state The sbt state
-   * @param args The command line arguments
+   *
+   * @param state    The sbt state
+   * @param args     The command line arguments
    * @param instance The running Docker Compose instance to test against
    */
   def runTestPass(implicit state: State, args: Seq[String], instance: Option[RunningInstanceInfo]): State = {
@@ -64,8 +67,9 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
    * Build up a set of parameters to pass as System Properties that can be accessed from Specs2
    * Compiles and binPackages the latest Test code.
    * Starts a test pass using the Specs2 Files Runner
-   * @param state The sbt state
-   * @param args The command line arguments
+   *
+   * @param state    The sbt state
+   * @param args     The command line arguments
    * @param instance The running Docker Compose instance to test against
    */
   def runTestPassSpecs2(implicit state: State, args: Seq[String], instance: Option[RunningInstanceInfo]): State = {
@@ -76,8 +80,9 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
    * Build up a set of parameters to pass as System Properties that can be accessed from Cucumber (Cukes)
    * Compiles and binPackages the latest Test code.
    * Starts a test pass using the Cucumber Runner
-   * @param state The sbt state
-   * @param args The command line arguments
+   *
+   * @param state    The sbt state
+   * @param args     The command line arguments
    * @param instance The running Docker Compose instance to test against
    */
   def runTestPassCucumber(implicit state: State, args: Seq[String], instance: Option[RunningInstanceInfo]): State = {
@@ -119,12 +124,7 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
       if (Process(testRunnerCommand).! == 0) state
       else state.fail
     } else {
-      val errMsg = if (true) {
-        s"Cannot find a $testDesc Jar dependency. Please make sure it is added to your sbt projects libraryDependencies."
-      } else {
-        ""
-      }
-      printBold(errMsg, suppressColor)
+      printBold(s"Cannot find a $testDesc Jar dependency. Please make sure it is added to your sbt projects libraryDependencies.", suppressColor)
       state
     }
   }

--- a/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
@@ -24,6 +24,7 @@ trait DockerComposeKeysLocal {
   val testCasesPackageTask = taskKey[File]("The sbt TaskKey to package the test cases used when running 'dockerComposeTest'. This defaults to the 'packageBin' task in the 'Test' Scope.")
   val testDependenciesClasspath = taskKey[String]("The path to all managed and unmanaged Test and Compile dependencies. This path needs to include the ScalaTest Jar for the tests to execute. This defaults to all managedClasspath and unmanagedClasspath in the Test and fullClasspath in the Compile Scope.")
   val testPassUseSpecs2 = settingKey[Boolean]("True if Specs2 is to be used to execute the test pass. This defaults to False and ScalaTest is used.")
+  val testPassUseCucumber = settingKey[Boolean]("True if Cucumber is to be used to execute the test pass. This defaults to False and ScalaTest is used.")
   val runningInstances = AttributeKey[List[RunningInstanceInfo]]("For Internal Use: Contains information on the set of running Docker Compose instances.")
   val variablesForSubstitution = settingKey[Map[String, String]]("A Map[String,String] of variables to substitute in your docker-compose file. These are substituted by the plugin and not using environment variables.")
   val variablesForSubstitutionTask = taskKey[Map[String, String]]("An sbt task that returns a Map[String,String] of variables to substitute in your docker-compose file. These are substituted by the plugin and not using environment variables.")

--- a/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
@@ -77,6 +77,7 @@ object DockerComposePlugin extends DockerComposePluginLocal {
     val testExecutionArgs = DockerComposeKeys.testExecutionArgs
     val testCasesJar = DockerComposeKeys.testCasesJar
     val testPassUseSpecs2 = DockerComposeKeys.testPassUseSpecs2
+    val testPassUseCucumber = DockerComposeKeys.testPassUseCucumber
     val suppressColorFormatting = DockerComposeKeys.suppressColorFormatting
     val scalaTestJar = DockerComposeKeys.testDependenciesClasspath
     val variablesForSubstitution = DockerComposeKeys.variablesForSubstitution
@@ -139,7 +140,7 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
       printDockerComposeInstances(state, args)
   }
 
-  lazy val dockerComposeTest = Command("dockerComposeTest", ("dockerComposeTest", "Executes ScalaTest test " +
+  lazy val dockerComposeTest = Command("dockerComposeTest", ("dockerComposeTest", "Executes ScalaTest, Specs2 or Cucumber test " +
     "cases against a newly started Docker Compose instance."),
     s"Supply '$skipPullArg' as a parameter to use local images instead of pulling the latest from the Docker Registry." +
       s"Supply '$skipBuildArg' as a parameter to use the current Docker image for the main project instead of building a new one." +
@@ -414,16 +415,23 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
     }
   }
 
-  def composeTestRunner(implicit state: State, args: Seq[String]): State = {
+  def composeTestRunner(state: State, args: Seq[String]): State = {
     val newState = getPersistedState(state)
 
     val requiresShutdown = getMatchingRunningInstance(newState, args).isEmpty
     val (preTestState, instance) = getTestPassInstance(newState, args)
 
-    val finalState = if (getSetting(testPassUseSpecs2))
-      runTestPassSpecs2(preTestState, args, instance)
-    else
-      runTestPass(preTestState, args, instance)
+    val cucumberState = if (getSetting(testPassUseCucumber)(preTestState))
+      runTestPassCucumber(preTestState, args, instance)
+    else {
+      state
+    }
+
+    val finalState = if (getSetting(testPassUseSpecs2)(preTestState)) {
+      runTestPassSpecs2(cucumberState, args, instance)
+    } else {
+      runTestPass(cucumberState, args, instance)
+    }
 
     if (requiresShutdown)
       stopDockerCompose(finalState, Seq(instance.get.instanceName))

--- a/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
@@ -415,22 +415,18 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
     }
   }
 
-  def composeTestRunner(state: State, args: Seq[String]): State = {
+  def composeTestRunner(implicit state: State, args: Seq[String]): State = {
     val newState = getPersistedState(state)
 
     val requiresShutdown = getMatchingRunningInstance(newState, args).isEmpty
     val (preTestState, instance) = getTestPassInstance(newState, args)
 
-    val cucumberState = if (getSetting(testPassUseCucumber)(preTestState))
+    val finalState = if (getSetting(testPassUseCucumber))
       runTestPassCucumber(preTestState, args, instance)
-    else {
-      state
-    }
-
-    val finalState = if (getSetting(testPassUseSpecs2)(preTestState)) {
-      runTestPassSpecs2(cucumberState, args, instance)
+    else if (getSetting(testPassUseSpecs2)) {
+      runTestPassSpecs2(preTestState, args, instance)
     } else {
-      runTestPass(cucumberState, args, instance)
+      runTestPass(preTestState, args, instance)
     }
 
     if (requiresShutdown)

--- a/src/main/scala/com/tapad/docker/DockerComposeSettings.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeSettings.scala
@@ -49,6 +49,7 @@ trait DockerComposeSettingsLocal extends PrintFormatting {
     testCasesJar := artifactPath.in(Test, packageBin).value.getAbsolutePath,
     testCasesPackageTask := (sbt.Keys.packageBin in Test).value,
     testPassUseSpecs2 := false,
+    testPassUseCucumber := false,
     suppressColorFormatting := System.getProperty("sbt.log.noformat", "false") == "true",
     variablesForSubstitution := Map[String, String](),
     variablesForSubstitutionTask := Map[String, String](),

--- a/src/main/scala/com/tapad/docker/ExecuteInput.scala
+++ b/src/main/scala/com/tapad/docker/ExecuteInput.scala
@@ -1,0 +1,113 @@
+package com.tapad.docker
+
+import com.tapad.docker.DockerComposeKeys.{ suppressColorFormatting, testCasesJar, testTagsToExecute }
+import sbt.State
+
+import scala.collection.Seq
+
+/**
+ * Represents the settings/input given to produce a test command-line.
+ */
+case class ExecuteInput(
+    runner: ComposeTestRunner,
+    testDependencyClasspath: String,
+    testParamsList: Seq[String],
+    debugSettings: String
+)(implicit
+  val state: State,
+    val args: Seq[String],
+    val instance: Option[RunningInstanceInfo]) {
+  def matches(regex: String) = testDependencyClasspath.matches(regex)
+
+  def testArgs = runner.getSetting(DockerComposeKeys.testExecutionArgs).split(" ").toSeq
+
+  def suppressColor = runner.getSetting(suppressColorFormatting)
+
+  def formattedClasspath = {
+    testDependencyClasspath.split("[;:,]", -1).mkString("\n")
+  }
+
+  override def toString = {
+    s"""Docker Compose Test Input:
+       |testParamsList: $testParamsList
+       |debugSettings: $debugSettings
+       |testClasspath: $formattedClasspath
+     """.stripMargin
+  }
+}
+
+object ExecuteInput {
+  type TestRunnerCommand = Seq[String]
+
+  /**
+   * Given an ExecuteInput, produce an option command-line used to execute some tests
+   */
+  type Invoke = PartialFunction[ExecuteInput, TestRunnerCommand]
+
+  /**
+   * A function which will execute ScalaTests given an [[ExecuteInput]]
+   */
+  val ScalaTest: PartialFunction[ExecuteInput, TestRunnerCommand] = {
+    case input: ExecuteInput if input.matches(".*org.scalatest.*") =>
+
+      val testTags = (input.runner.getArgValue(input.runner.testTagOverride, input.args) match {
+        case Some(tag) => tag
+        case None => input.runner.getSetting(testTagsToExecute)(input.state)
+      }).split(',').filter(_.nonEmpty).map(tag => s"-n $tag").mkString(" ")
+
+      val noColorOption = if (input.suppressColor) "W" else ""
+
+      val jarName = input.runner.getSetting(testCasesJar)(input.state)
+
+      val testRunnerCommand: Seq[String] = (Seq("java", input.debugSettings) ++
+        input.testParamsList ++
+        Seq("-cp", input.testDependencyClasspath, "org.scalatest.tools.Runner", s"-o$noColorOption") ++
+        input.testArgs ++
+        Seq("-R", s"${jarName.replace(" ", "\\ ")}") ++
+        testTags.split(" ").toSeq ++
+        input.testParamsList).filter(_.nonEmpty)
+
+      testRunnerCommand
+  }
+
+  /**
+   * A function which will execute Specs2 tests given an [[ExecuteInput]]
+   */
+  val Specs2: PartialFunction[ExecuteInput, TestRunnerCommand] = {
+    case input: ExecuteInput if input.matches(".*org.specs2.*") =>
+
+      val noColorOption = if (input.suppressColor) "-Dspecs2.color=false" else ""
+
+      val testParamsList = input.testParamsList
+      val testRunnerCommand = (Seq("java", input.debugSettings, noColorOption) ++
+        input.testParamsList ++
+        Seq("-cp", input.testDependencyClasspath, "org.specs2.runner.files") ++
+        input.testArgs ++
+        testParamsList).filter(_.nonEmpty)
+
+      testRunnerCommand
+  }
+
+  /**
+   * A function which will execute Cucumber tests given an [[ExecuteInput]]
+   *
+   * @see https://cucumber.io/docs/reference/jvm#java
+   */
+  val Cucumber: PartialFunction[ExecuteInput, TestRunnerCommand] = {
+    case input: ExecuteInput if input.matches(".*cucumber.*") =>
+
+      val cucumberArgs = {
+        val gluePath = "classpath:"
+        val featurePath = "classpath:"
+
+        val noColorOption = if (input.suppressColor) "-m" else ""
+        Seq("--glue", gluePath, noColorOption, featurePath) ++ input.testArgs
+      }
+      val testRunnerCommand = (Seq("java", input.debugSettings) ++
+        input.testParamsList ++
+        Seq("-cp", input.testDependencyClasspath, "cucumber.api.cli.Main") ++
+        cucumberArgs).filter(_.nonEmpty)
+
+      testRunnerCommand
+  }
+}


### PR DESCRIPTION
I've had a go at pulling out a common 'ExecuteInput' command class which can be (is) shared by
Specs2 and Cucumber.

This may not be the direction you're taking with it, but it at least addressed my use case of wanting to be able to run cucumber behave tests with your handy plugin!

Anyway, it's there for your consideration w/ the new 'basic-with-tests-cucumber' example.

The example itself is a bit noddy, but it at least it demonstrates the basic functionality. The ouput of 'sbt dockerComposeTest' is e.g.:



```scala
......................

20 Scenarios (20 passed)
60 Steps (60 passed)
0m0.775s

[info] Compiling and Packaging test cases using testCasesPackageTask ...
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
Discovery starting.
Discovery completed in 98 milliseconds.
Run starting. Expected test count is: 0
DiscoverySuite:
Run completed in 131 milliseconds.
Total number of tests run: 0
Suites: completed 1, aborted 0
Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0
No tests were executed.
Stopping and removing local Docker instance: XXXXXX

```

And the specs2 example still runs as well ... the sample output:


```scala

Executing specifications
printers are org.specs2.reporter.TextPrinter$@793be5ca
  the pattern used to match specification objects is: \s*object\s*(.*Spec)\s*extends\s*.*
  the pattern used to match specification classes is: \s*class\s*(.*Spec)\s*extends\s*.*
Searching for specifications in file: /Users/aaron/dev/playground/sbt-docker-compose/examples/basic-with-tests-specs2/src/test/scala/BasicAppSpec.scala
  found classes: BasicAppSpec
Attempting to connect to: localhost:32768, container id is 39870c581b6f
[info] BasicAppSpec
[info] 
[info] + Validate that the Docker Compose endpoint returns a success code and the string 'Hello, World!'
[info] 
[info] 
[info] Total for specification BasicAppSpec
[info] Finished in 172 ms
1 example, 0 failure, 0 error
[info] 
Finished the execution of 1 specifications

Stopping and removing local Docker instance: 686638
Stopping 686638_basic_1 ... done
Removing 686638_basic_1 ... done
```