### PR TITLE
ScalaTest: ability to customize reporter configuration parameters (such as full stack traces)

### DIFF
--- a/src/main/scala/com/tapad/docker/ExecuteInput.scala
+++ b/src/main/scala/com/tapad/docker/ExecuteInput.scala
@@ -55,13 +55,13 @@ object ExecuteInput {
         case None => input.runner.getSetting(testTagsToExecute)(input.state)
       }).split(',').filter(_.nonEmpty).map(tag => s"-n $tag").mkString(" ")
 
-      val noColorOption = if (input.suppressColor) "W" else ""
+      val outputReporterOptions = if (input.suppressColor) "-oW" else ""
 
       val jarName = input.runner.getSetting(testCasesJar)(input.state)
 
       val testRunnerCommand: Seq[String] = (Seq("java", input.debugSettings) ++
         input.testParamsList ++
-        Seq("-cp", input.testDependencyClasspath, "org.scalatest.tools.Runner", s"-o$noColorOption") ++
+        Seq("-cp", input.testDependencyClasspath, "org.scalatest.tools.Runner", outputReporterOptions) ++
         input.testArgs ++
         Seq("-R", s"${jarName.replace(" ", "\\ ")}") ++
         testTags.split(" ").toSeq ++


### PR DESCRIPTION
Usually, it's easier to debug reason of failed test when having full stack trace of the failure.
ScalaTest test runner can enable it with -oF command line option (http://www.scalatest.org/user_guide/using_the_runner). 
sbt follows this approach, so `sbt test` and `sbt testOnly ...` can have full stack traces enabled by adding this option.

Unfortunately, with sbt-docker-compose it's not possible at the moment - I can specify additional ScalaTest options with `testExecutionArgs`,
but if I specify `-oF` among these options - ScalaTest fails: `java.lang.IllegalArgumentException: Only one -o allowed`.

I suggest to skip empty non-significant `-o` parameter when `suppressColorFormatting` is `false` - 
then we'll be able to specify `-o...` parameters in `testExecutionArgs`.