### PR TITLE
Support being able to provide a '-o' argument with configuration parameters to the 'testExecutionArgs' plugin setting

### DIFF
--- a/src/main/scala/com/tapad/docker/ComposeTestRunner.scala
+++ b/src/main/scala/com/tapad/docker/ComposeTestRunner.scala
@@ -18,7 +18,12 @@ trait ComposeTestRunner extends SettingsHelper with PrintFormatting {
   def binPackageTests(implicit state: State): Unit = {
     val extracted = Project.extract(state)
     state.globalLogging.full.info(s"Compiling and Packaging test cases using ${testCasesPackageTask.key.label} ...")
-    extracted.runTask(testCasesPackageTask, state)
+    try {
+      extracted.runTask(testCasesPackageTask, state)
+    } catch {
+      case e: Exception =>
+        throw TestCodeCompilationException(e.getMessage)
+    }
   }
 
   /**


### PR DESCRIPTION
Currently the plugin does not allow you to specify your own parameters values for the '-o' setting.

This is a modified version of: https://github.com/Tapad/sbt-docker-compose/pull/105 as the default '-o' option needs to exist to see the test case output in the console.

This code also includes a fix for https://github.com/Tapad/sbt-docker-compose/issues/107 where the newly started Docker container is not cleaned up when there is a test code compilation error when running `dockerComposeTest`.