### PR TITLE
Configurable delay between container launch and test start

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ plugin will attempt to locate it in one of three places with the precedence orde
 
 5) Optional: There are a number of optional Keys that can be set as well if you want to override the default settings:
    ```
+    composeContainerPauseBeforeTestSeconds := //Delay between containers start and test execution, seconds. Default is 0 seconds - no delay
     composeFile := // Specify the full path to the Compose File to use to create your test instance. It defaults to docker-compose.yml in your resources folder.   
     composeServiceName := // Specify the name of the service in the Docker Compose file being tested. This setting prevents the service image from being pull down from the Docker Registry. It defaults to the sbt Project name.
     composeServiceVersionTask := // The version to tag locally built images with in the docker-compose file. This defaults to the 'version' SettingKey.

--- a/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
@@ -6,6 +6,7 @@ import java.io._
 object DockerComposeKeys extends DockerComposeKeysLocal
 
 trait DockerComposeKeysLocal {
+  val composeContainerPauseBeforeTestSeconds = settingKey[Int]("Delay between containers start and test execution, seconds. Default is 0 seconds - no delay")
   val composeFile = settingKey[String]("Specify the full path to the Compose File to use to create your test instance. It defaults to docker-compose.yml in your resources folder.")
   val composeServiceName = settingKey[String]("The name of the service in the Docker Compose file being tested. This setting prevents the service image from being pull down from the Docker Registry. This defaults to the Project name.")
   val composeServiceVersionTask = taskKey[String]("The version to tag locally built images with in the docker-compose file. This defaults to the 'version' SettingKey.")

--- a/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
@@ -67,6 +67,7 @@ object DockerComposePlugin extends DockerComposePluginLocal {
 
   //Import these settings so that they can easily be configured from a projects build.sbt
   object autoImport {
+    val composeContainerPauseBeforeTestSeconds = DockerComposeKeys.composeContainerPauseBeforeTestSeconds
     val composeFile = DockerComposeKeys.composeFile
     val composeServiceName = DockerComposeKeys.composeServiceName
     val composeServiceVersionTask = DockerComposeKeys.composeServiceVersionTask
@@ -427,6 +428,14 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
 
     val requiresShutdown = getMatchingRunningInstance(newState, args).isEmpty
     val (preTestState, instance) = getTestPassInstance(newState, args)
+
+    val seconds = getSetting(composeContainerPauseBeforeTestSeconds)
+
+    if (seconds > 0) {
+      print(s"Sleeping $seconds seconds to get ready for the tests")
+      Thread.sleep(1000 * seconds)
+      print("Wake up and starting the tests")
+    }
 
     //Ensure that if an exception is thrown when building the test code or during the test pass that
     //the instance that was started is cleaned up

--- a/src/main/scala/com/tapad/docker/DockerComposeSettings.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeSettings.scala
@@ -32,6 +32,7 @@ trait DockerComposeSettingsLocal extends PrintFormatting {
     composeRemoveNetworkOnShutdown := true,
     composeRemoveTempFileOnShutdown := true,
     composeContainerStartTimeoutSeconds := 500,
+    composeContainerPauseBeforeTestSeconds := 0,
     dockerMachineName := "default",
     dockerImageCreationTask := printError("***Warning: The 'dockerImageCreationTask' has not been defined. " +
       "Please configure this setting to have Docker images built.***", suppressColorFormatting.value),


### PR DESCRIPTION
Some containers (such as official Oracle) report as started before they've actually completed all initialization, so the tests fail if they start immediately after finishing of containers start. In order to overcome these issues we use a modified version of the plugin which supports additional parameter - `composeContainerPauseBeforeTestSeconds`. It specifies a delay to wait before starting the tests. Would be great to have such functionality in mainstream version. 