### PR TITLE
force instance name from config

### DIFF
--- a/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeKeys.scala
@@ -16,6 +16,7 @@ trait DockerComposeKeysLocal {
   val composeRemoveTempFileOnShutdown = settingKey[Boolean]("True if a Docker Compose should remove the post Custom Tag processed Compose File on shutdown. This defaults to True.")
   val composeContainerStartTimeoutSeconds = settingKey[Int]("The amount of time in seconds to wait for the containers in a Docker Compose instance to start. Defaults to 500 seconds.")
   val dockerMachineName = settingKey[String]("If running on OSX the name of the Docker Machine Virtual machine being used. If not overridden it is set to 'default'")
+  val composeInstanceName = settingKey[String]("Force instance name instead of auto-generating random one")
   val dockerImageCreationTask = taskKey[Any]("The sbt task used to create a Docker image. For sbt-docker this should be set to 'docker.value' for the sbt-native-packager this should be set to '(publishLocal in Docker).value'.")
   val suppressColorFormatting = settingKey[Boolean]("True to suppress all color formatting in the output from the plugin. This defaults to the value of the 'sbt.log.noformat' property.")
   val testTagsToExecute = settingKey[String]("Set of ScalaTest Tags to execute when dockerComposeTest is run. Separate multiple tags by a comma. It defaults to executing all tests.")
@@ -29,4 +30,5 @@ trait DockerComposeKeysLocal {
   val runningInstances = AttributeKey[List[RunningInstanceInfo]]("runningInstances", "For Internal Use: Contains information on the set of running Docker Compose instances.")
   val variablesForSubstitution = settingKey[Map[String, String]]("A Map[String,String] of variables to substitute in your docker-compose file. These are substituted by the plugin and not using environment variables.")
   val variablesForSubstitutionTask = taskKey[Map[String, String]]("An sbt task that returns a Map[String,String] of variables to substitute in your docker-compose file. These are substituted by the plugin and not using environment variables.")
+
 }

--- a/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
@@ -76,6 +76,7 @@ object DockerComposePlugin extends DockerComposePluginLocal {
     val composeRemoveNetworkOnShutdown = DockerComposeKeys.composeRemoveNetworkOnShutdown
     val composeRemoveTempFileOnShutdown = DockerComposeKeys.composeRemoveTempFileOnShutdown
     val composeContainerStartTimeoutSeconds = DockerComposeKeys.composeContainerStartTimeoutSeconds
+    val composeInstanceName = DockerComposeKeys.composeInstanceName
     val dockerMachineName = DockerComposeKeys.dockerMachineName
     val dockerImageCreationTask = DockerComposeKeys.dockerImageCreationTask
     val testDependenciesClasspath = DockerComposeKeys.testDependenciesClasspath
@@ -265,7 +266,8 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
 
     //Generate random instance name so that it won't collide with other instances running and so that it can be uniquely
     //identified from the list of running containers
-    val instanceName = generateInstanceName(state)
+    val settingInstanceName = getSetting(composeInstanceName)
+    val instanceName = if (settingInstanceName != "default") settingInstanceName else generateInstanceName(state)
 
     val newState = Try {
       val ret = dockerComposeUp(instanceName, updatedComposePath)

--- a/src/main/scala/com/tapad/docker/DockerComposeSettings.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposeSettings.scala
@@ -26,6 +26,7 @@ trait DockerComposeSettingsLocal extends PrintFormatting {
     },
     // By default set the Compose service name to be that of the sbt Project Name
     composeServiceName := name.value.toLowerCase,
+    composeInstanceName := "default",
     composeServiceVersionTask := version.value,
     composeNoBuild := false,
     composeRemoveContainersOnShutdown := true,


### PR DESCRIPTION
This little change allows forcing instance name (in fact it should be numeric due to other logics in plugin that I didn't dare to touch). Then the network name can be known in advance.

The following scenario is supported by this change:
- Jenkinsfile using docker 'agent' to build the application and to run the end-to-end tests
- Agent container and all compose containers have to share the same docker network
- Docker network needs to be created in the very beginning, before agent container starts
- In current implementation, sbt-docker-compose plugin creates random networks 
