### PR TITLE
Support new docker for mac OS name

### DIFF
--- a/src/main/scala/com/tapad/docker/DockerCommands.scala
+++ b/src/main/scala/com/tapad/docker/DockerCommands.scala
@@ -81,6 +81,7 @@ trait DockerCommands {
   def isDockerForMacEnvironment: Boolean = {
     val info = Process("docker info").!!
     info.contains("Operating System: Docker for Mac") ||
+      info.contains("Operating System: Docker Desktop") ||
       (info.contains("Operating System: Alpine Linux") && info.matches("(?s).*Kernel Version:.*-moby.*"))
   }
 


### PR DESCRIPTION
Docker-for-mac changed the name of the Operating system in the docker info result