### PR TITLE
Add support for Docker Compose API v2

### DIFF
--- a/src/main/scala/com/tapad/docker/DockerCommands.scala
+++ b/src/main/scala/com/tapad/docker/DockerCommands.scala
@@ -41,9 +41,14 @@ trait DockerCommands {
     Process(s"docker-machine ip $machineName").!!.trim
   }
 
-  def getDockerContainerId(instanceName: String, serviceName: String): String = {
+  def getDockerContainerIdLegacy(instanceName: String, serviceName: String): String = {
     //Docker replaces '/' with '_' in the identifier string so search for replaced version
     Process(s"""docker ps --all --filter=name=${instanceName.replace('/', '_')}_${serviceName}_ --format=\"{{.ID}}\"""").!!.trim().replaceAll("\"", "")
+  }
+
+  def getDockerContainerId(instanceName: String, serviceName: String): String = {
+    // support for V2 Docker Compose API https://github.com/docker/compose#about-update-and-backward-compatibility
+    Process(s"""docker ps --all --filter=name=${instanceName.replace('/', '_')}-${serviceName}-1 --format=\"{{.ID}}\"""").!!.trim().replaceAll("\"", "")
   }
 
   def getDockerContainerInfo(containerId: String): String = {

--- a/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
+++ b/src/main/scala/com/tapad/docker/DockerComposePlugin.scala
@@ -569,13 +569,15 @@ class DockerComposePluginLocal extends AutoPlugin with ComposeFile with DockerCo
       if (verbose)
         print(s"Waiting for container Id to be available for service '$serviceName' time remaining: ${deadline.timeLeft.toSeconds}")
 
+      val containerIdLegacy = getDockerContainerIdLegacy(instanceName, serviceName)
       val containerId = getDockerContainerId(instanceName, serviceName)
+      val finalContainerId = if (containerIdLegacy.isEmpty) containerId else containerIdLegacy
 
-      if (containerId.isEmpty) {
+      if (finalContainerId.isEmpty) {
         Thread.sleep(2000)
         tryGetContainerId(state, instanceName, serviceName, deadline)
       } else {
-        Some(containerId)
+        Some(finalContainerId)
       }
     }
     case false => None


### PR DESCRIPTION
- add a way for getting container ID using v2 API
- use container ID through v2 API if legacy API fails to locate that ID
- V2 API filtering is prone to name clashes so added scaling instance suffix when filtering running services